### PR TITLE
Include wording if the directory doesnt exist for ST3

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Installation for Sublime Text 2/3
 - install Package Control (https://sublime.wbond.net/installation)
 - install sublime-tern plugin (cmd+shift+p -> install package -> TernJS -> restart sublime)
 - `cd` to Sublime Text packages directory (`~/Library/Application Support/Sublime Text 3/Packages` on Mac OS X) (Is your TernJS package fetched as binary file? [see here](https://github.com/Slava/tern-meteor/issues/7))
-- `cd TernJS/ternjs/plugin`
+- `cd TernJS/ternjs/plugin` (or create the directories if they doesn't exist first - `mkdir -p TernJS/ternjs/plugin`)
 - copy over meteor.js file here
 - create a new sublime project, save it, add files
 - edit project configuration (menu->project->edit project)


### PR DESCRIPTION
Added wording incase the plugin directory doesn't exist for TernJS on Sublime Text 3
