### PR TITLE
meteor plugin as installed package. See http://ternjs.net/doc/manual.html#plugin_third_party

### DIFF
--- a/meteor.js
+++ b/meteor.js
@@ -1,6 +1,6 @@
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
-    return mod(require("../lib/infer"), require("../lib/tern"), require);
+    return mod(require("tern/lib/infer"), require("tern/lib/tern"), require);
   if (typeof define == "function" && define.amd) // AMD
     return define(["../lib/infer", "../lib/tern"], mod);
   mod(tern, tern);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "tern-meteor",
+  "license": "MIT",
+  "version": "0.1.0",
+  "main": "meteor.js",
+  "author": "Slava Kim <slava@meteor.com>",
+  "description": "This is a plugin for TernJS bringing support for Meteor JavaScript Framework.",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/Slava/tern-meteor.git"
+  },
+  "dependencies": {
+    "tern": "^0.7.0",
+    "acorn": "~0.5.0"
+  },  
+  "keywords": [
+    "tern",
+    "meteor"
+  ]
+}


### PR DESCRIPTION
This PR gives you the capability to avoid setting meteor.js inside tern/plugin folder but setting tern-meteor folder inside your node_modules. More once you will publish tern-meteor with npm publish, you will able to install it with npm install. See http://ternjs.net/doc/manual.html#plugin_third_party for explanation how tern loads tern plugin.
