### PR TITLE
don't uses relative path for node require.

### DIFF
--- a/meteor.js
+++ b/meteor.js
@@ -1,6 +1,6 @@
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
-    return mod(require("../lib/infer"), require("../lib/tern"), require);
+    return mod(require("tern/lib/infer"), require("tern/lib/tern"), require);
   if (typeof define == "function" && define.amd) // AMD
     return define(["../lib/infer", "../lib/tern"], mod);
   mod(tern, tern);


### PR DESCRIPTION
This patch is the first step to use tern-meteor ouside the tern folder. It will give the capability to install tern-meteor with npm install (instead of copying.pasting at hand the meteor.js in the tern/plugin folder).

Note this PR doesn't break the capability to copy/paste the meteor.js in the tern/plugin folder
